### PR TITLE
修复带路径反代404

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
     let title = 'vList - ',
         rootPath = "{{.RootPath}}",
         currentPath = "{{.CurrentPath}}",
+        proxyPath = location.pathname.replace(currentPath,""),
         rawData = "{{.RawData}}",
         $$ = mdui.JQ;
     if (currentPath === "/") {
@@ -130,7 +131,7 @@
             }
             for (; j < locPathArr.length; j++) {
                 localHref += "/" + locPathArr[j];
-                navTemp = `<a class="nav-a" href="//${window.location.host}${localHref}">${locPathArr[j]}</a>`;
+                navTemp = `<a class="nav-a" href="//${window.location.host}${proxyPath}${localHref}">${locPathArr[j]}</a>`;
                 locArray.push(navTemp)
             }
         }


### PR DESCRIPTION
修复当反代在一个路径下时，面包屑导航的herf没有带上反代链接导致404的问题